### PR TITLE
Add basic cafe API with Querydsl

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'org.springframework.boot' version '3.5.0'
     id 'io.spring.dependency-management' version '1.1.7'
     id 'org.jetbrains.kotlin.plugin.jpa' version '1.9.25'
+    id 'org.jetbrains.kotlin.kapt' version '1.9.25'
 }
 
 group = 'com.yellowcow'
@@ -11,7 +12,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 
@@ -27,8 +28,11 @@ dependencies {
     implementation 'com.fasterxml.jackson.module:jackson-module-kotlin'
     implementation 'org.jetbrains.kotlin:kotlin-reflect'
     implementation 'org.springframework.session:spring-session-core'
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    kapt 'com.querydsl:querydsl-apt:5.0.0:jakarta'
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
     runtimeOnly 'org.postgresql:postgresql'
+    runtimeOnly 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.jetbrains.kotlin:kotlin-test-junit5'
     testImplementation 'org.springframework.security:spring-security-test'
@@ -41,10 +45,22 @@ kotlin {
     }
 }
 
+sourceSets {
+    main {
+        java {
+            srcDirs += 'build/generated/source/kapt/main'
+        }
+    }
+}
+
 allOpen {
     annotation 'jakarta.persistence.Entity'
     annotation 'jakarta.persistence.MappedSuperclass'
     annotation 'jakarta.persistence.Embeddable'
+}
+
+kapt {
+    correctErrorTypes = true
 }
 
 tasks.named('test') {

--- a/src/main/kotlin/com/yellowcow/cafewhereigo/cafe/Cafe.kt
+++ b/src/main/kotlin/com/yellowcow/cafewhereigo/cafe/Cafe.kt
@@ -1,0 +1,17 @@
+package com.yellowcow.cafewhereigo.cafe
+
+import jakarta.persistence.*
+
+@Entity
+class Cafe(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    val name: String,
+    val region: String,
+    val hasWifi: Boolean,
+    val hasParking: Boolean,
+    val hasSocket: Boolean,
+    val theme: String
+)

--- a/src/main/kotlin/com/yellowcow/cafewhereigo/cafe/CafeController.kt
+++ b/src/main/kotlin/com/yellowcow/cafewhereigo/cafe/CafeController.kt
@@ -1,0 +1,37 @@
+package com.yellowcow.cafewhereigo.cafe
+
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/cafes")
+class CafeController(private val cafeService: CafeService) {
+
+    @GetMapping
+    fun search(condition: CafeSearchCondition): List<Cafe> {
+        return cafeService.search(condition)
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun create(@RequestBody request: CreateCafeRequest): Cafe {
+        val cafe = Cafe(
+            name = request.name,
+            region = request.region,
+            hasWifi = request.hasWifi,
+            hasParking = request.hasParking,
+            hasSocket = request.hasSocket,
+            theme = request.theme
+        )
+        return cafeService.addCafe(cafe)
+    }
+}
+
+data class CreateCafeRequest(
+    val name: String,
+    val region: String,
+    val hasWifi: Boolean,
+    val hasParking: Boolean,
+    val hasSocket: Boolean,
+    val theme: String
+)

--- a/src/main/kotlin/com/yellowcow/cafewhereigo/cafe/CafeRepository.kt
+++ b/src/main/kotlin/com/yellowcow/cafewhereigo/cafe/CafeRepository.kt
@@ -1,0 +1,5 @@
+package com.yellowcow.cafewhereigo.cafe
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CafeRepository : JpaRepository<Cafe, Long>, CafeRepositoryCustom

--- a/src/main/kotlin/com/yellowcow/cafewhereigo/cafe/CafeRepositoryCustom.kt
+++ b/src/main/kotlin/com/yellowcow/cafewhereigo/cafe/CafeRepositoryCustom.kt
@@ -1,0 +1,5 @@
+package com.yellowcow.cafewhereigo.cafe
+
+interface CafeRepositoryCustom {
+    fun search(condition: CafeSearchCondition): List<Cafe>
+}

--- a/src/main/kotlin/com/yellowcow/cafewhereigo/cafe/CafeRepositoryImpl.kt
+++ b/src/main/kotlin/com/yellowcow/cafewhereigo/cafe/CafeRepositoryImpl.kt
@@ -1,0 +1,24 @@
+package com.yellowcow.cafewhereigo.cafe
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.yellowcow.cafewhereigo.cafe.QCafe
+import org.springframework.stereotype.Repository
+
+@Repository
+class CafeRepositoryImpl(
+    private val queryFactory: JPAQueryFactory
+) : CafeRepositoryCustom {
+
+    override fun search(condition: CafeSearchCondition): List<Cafe> {
+        val cafe = QCafe.cafe
+        return queryFactory.selectFrom(cafe)
+            .where(
+                condition.region?.let { cafe.region.eq(it) },
+                condition.hasWifi?.let { cafe.hasWifi.eq(it) },
+                condition.hasParking?.let { cafe.hasParking.eq(it) },
+                condition.hasSocket?.let { cafe.hasSocket.eq(it) },
+                condition.theme?.let { cafe.theme.eq(it) }
+            )
+            .fetch()
+    }
+}

--- a/src/main/kotlin/com/yellowcow/cafewhereigo/cafe/CafeSearchCondition.kt
+++ b/src/main/kotlin/com/yellowcow/cafewhereigo/cafe/CafeSearchCondition.kt
@@ -1,0 +1,9 @@
+package com.yellowcow.cafewhereigo.cafe
+
+data class CafeSearchCondition(
+    val region: String? = null,
+    val hasWifi: Boolean? = null,
+    val hasParking: Boolean? = null,
+    val hasSocket: Boolean? = null,
+    val theme: String? = null
+)

--- a/src/main/kotlin/com/yellowcow/cafewhereigo/cafe/CafeService.kt
+++ b/src/main/kotlin/com/yellowcow/cafewhereigo/cafe/CafeService.kt
@@ -1,0 +1,18 @@
+package com.yellowcow.cafewhereigo.cafe
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class CafeService(private val cafeRepository: CafeRepository) {
+
+    @Transactional(readOnly = true)
+    fun search(condition: CafeSearchCondition): List<Cafe> {
+        return cafeRepository.search(condition)
+    }
+
+    @Transactional
+    fun addCafe(cafe: Cafe): Cafe {
+        return cafeRepository.save(cafe)
+    }
+}

--- a/src/main/kotlin/com/yellowcow/cafewhereigo/community/CommunityPost.kt
+++ b/src/main/kotlin/com/yellowcow/cafewhereigo/community/CommunityPost.kt
@@ -1,0 +1,20 @@
+package com.yellowcow.cafewhereigo.community
+
+import com.yellowcow.cafewhereigo.cafe.Cafe
+import jakarta.persistence.*
+import java.time.LocalDateTime
+
+@Entity
+class CommunityPost(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cafe_id")
+    val cafe: Cafe,
+
+    val title: String,
+    val content: String,
+    val createdAt: LocalDateTime = LocalDateTime.now()
+)

--- a/src/main/kotlin/com/yellowcow/cafewhereigo/community/CommunityPostController.kt
+++ b/src/main/kotlin/com/yellowcow/cafewhereigo/community/CommunityPostController.kt
@@ -1,0 +1,26 @@
+package com.yellowcow.cafewhereigo.community
+
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/posts")
+class CommunityPostController(private val communityPostService: CommunityPostService) {
+
+    @GetMapping
+    fun list(): List<CommunityPost> {
+        return communityPostService.listAll()
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun create(@RequestBody request: CreatePostRequest): CommunityPost {
+        return communityPostService.addPost(request.cafeId, request.title, request.content)
+    }
+}
+
+data class CreatePostRequest(
+    val cafeId: Long,
+    val title: String,
+    val content: String
+)

--- a/src/main/kotlin/com/yellowcow/cafewhereigo/community/CommunityPostRepository.kt
+++ b/src/main/kotlin/com/yellowcow/cafewhereigo/community/CommunityPostRepository.kt
@@ -1,0 +1,5 @@
+package com.yellowcow.cafewhereigo.community
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CommunityPostRepository : JpaRepository<CommunityPost, Long>

--- a/src/main/kotlin/com/yellowcow/cafewhereigo/community/CommunityPostService.kt
+++ b/src/main/kotlin/com/yellowcow/cafewhereigo/community/CommunityPostService.kt
@@ -1,0 +1,24 @@
+package com.yellowcow.cafewhereigo.community
+
+import com.yellowcow.cafewhereigo.cafe.CafeRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class CommunityPostService(
+    private val communityPostRepository: CommunityPostRepository,
+    private val cafeRepository: CafeRepository
+) {
+
+    @Transactional(readOnly = true)
+    fun listAll(): List<CommunityPost> {
+        return communityPostRepository.findAll()
+    }
+
+    @Transactional
+    fun addPost(cafeId: Long, title: String, content: String): CommunityPost {
+        val cafe = cafeRepository.findById(cafeId).orElseThrow()
+        val post = CommunityPost(cafe = cafe, title = title, content = content)
+        return communityPostRepository.save(post)
+    }
+}

--- a/src/main/kotlin/com/yellowcow/cafewhereigo/config/QuerydslConfig.kt
+++ b/src/main/kotlin/com/yellowcow/cafewhereigo/config/QuerydslConfig.kt
@@ -1,0 +1,15 @@
+package com.yellowcow.cafewhereigo.config
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import jakarta.persistence.EntityManager
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class QuerydslConfig(private val entityManager: EntityManager) {
+
+    @Bean
+    fun jpaQueryFactory(): JPAQueryFactory {
+        return JPAQueryFactory(entityManager)
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,14 @@
 spring:
   application:
     name: CafeWhereIGo
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=PostgreSQL
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
## Summary
- set Java toolchain to 21
- add Querydsl support via kapt
- configure H2 datasource for local development
- implement minimal Cafe entity, repository, service, and controller
- provide Querydsl configuration bean
- add community posts so users can share cafe experiences

## Testing
- `./gradlew build -x test`


------
https://chatgpt.com/codex/tasks/task_e_6852a145ff28832b839d4c2ea3b5bc8b